### PR TITLE
Bug #125513 fix: Class 'EasyBlogRouter' not found error message after updating EasyBlog to 5.2.3

### DIFF
--- a/easyblog/easyblog.xml
+++ b/easyblog/easyblog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" type="plugin" group="api" method="upgrade">
     <name>Api - Easyblog</name>
-    <version>1.8.5</version>
+    <version>2.2.0</version>
     <creationDate>10/11/2014</creationDate>
     <author>Techjoomla</author> 
     <authorEmail>extensions@techjoomla.com</authorEmail> 

--- a/easyblog/helper/simpleschema.php
+++ b/easyblog/helper/simpleschema.php
@@ -88,7 +88,7 @@ class EasyBlogSimpleSchema_plg
 		$item->category->categoryid = $category->id;
 		$item->category->title = $category->title;
 		
-		$item->url = JURI::root() . trim(EasyBlogRouter::_('index.php?option=com_easyblog&view=entry&id=' . $blog->id ), '/');
+		$item->url = JURI::root() . trim(EBR::_('index.php?option=com_easyblog&view=entry&id=' . $blog->id ), '/');
 		
 		// Tags
 		$modelPT	= EasyBlogHelper::getModel( 'PostTag' );
@@ -207,7 +207,7 @@ class EasyBlogSimpleSchema_4
 		$item->category->categoryid = $category->id;
 		$item->category->title = $category->title;
 		
-		$item->url = JURI::root() . trim(EasyBlogRouter::_('index.php?option=com_easyblog&view=entry&id=' . $blog->id ), '/');
+		$item->url = JURI::root() . trim(EBR::_('index.php?option=com_easyblog&view=entry&id=' . $blog->id ), '/');
 		
 		// Tags
 		$modelPT	= EasyBlogHelper::getModel( 'PostTag' );


### PR DESCRIPTION

**Summary of Changes**

I have changed the **EasyBlogRouter** class name to **EBR**. 